### PR TITLE
fix hermes support

### DIFF
--- a/MessageWebView.js
+++ b/MessageWebView.js
@@ -3,11 +3,11 @@ import { View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 // https://github.com/react-native-community/react-native-webview/releases/tag/v5.0.0
-const patchPostMessageJsCode = `(${String(function() {
+const patchPostMessageJsCode = `(function() {
   window.postMessage = function(data) {
     window.ReactNativeWebView.postMessage(data);
   };
-})})();`;
+})();`;
 
 export default class MessageWebView extends React.Component {
   constructor(props) {


### PR DESCRIPTION
After enabling Hermes, react-native-webview injectScript would be broken.

change it to pure string instead of Stringfy a Function.

ref: https://github.com/facebook/hermes/issues/288